### PR TITLE
add cookie secret shared via mongodb

### DIFF
--- a/db/model.go
+++ b/db/model.go
@@ -9,7 +9,7 @@ import (
 
 //EnsureIndex make sure indices are created on certain collection.
 func EnsureIndex(collectionName string, index mgo.Index) {
-	session := getSession()
+	session := GetSession()
 	defer session.Close()
 
 	c := GetCollection(session, collectionName)
@@ -28,13 +28,17 @@ func GetCollection(session *mgo.Session, collectionName string) *mgo.Collection 
 	return session.DB(DB_NAME).C(collectionName)
 }
 
-//getSession blocking call until session is ready.
-func getSession() *mgo.Session {
+//GetSession blocking call until session is ready.
+func GetSession() *mgo.Session {
 	for {
 		if session := NewSession(); session != nil {
 			return session
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
+}
+
+func IsDup(err error) bool {
+	return (err == ErrDuplicate || mgo.IsDup(err))
 }

--- a/identityservice/globalconfig/globalconfig.go
+++ b/identityservice/globalconfig/globalconfig.go
@@ -1,0 +1,81 @@
+package globalconfig
+
+import (
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/itsyouonline/identityserver/db"
+)
+
+const (
+	mongoCollectionName = "globalconfig"
+)
+
+type GlobalConfig struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// InitModels initialize models in mongo, if required
+func InitModels() {
+	// TODO: Use model tags to ensure indices/constraints
+	index := mgo.Index{
+		Key:      []string{"key"},
+		Unique:   true,
+		DropDups: true,
+	}
+
+	db.EnsureIndex(mongoCollectionName, index)
+}
+
+// Manager is used to store settings
+type Manager struct {
+	session    *mgo.Session
+	collection *mgo.Collection
+}
+
+func getConfigCollection(session *mgo.Session) *mgo.Collection {
+	return db.GetCollection(session, mongoCollectionName)
+}
+
+// NewManager creates and initializes a new Manager
+func NewManager() *Manager {
+	session := db.GetSession()
+	return &Manager{
+		session:    session,
+		collection: getConfigCollection(session),
+	}
+}
+
+// GetByGet return a config key/value from key name
+func (m *Manager) GetByKey(key string) (*GlobalConfig, error) {
+	var config GlobalConfig
+
+	err := m.collection.Find(bson.M{"key": key}).One(&config)
+
+	return &config, err
+}
+
+func (m *Manager) Exists(key string) (bool, error) {
+	count, err := m.collection.Find(bson.M{"key": key}).Count()
+
+	return count >= 1, err
+}
+
+// Insert a config key
+func (m *Manager) Insert(c *GlobalConfig) error {
+	err := m.collection.Insert(c)
+
+	return err
+}
+
+// Delete a config key
+func (m *Manager) Delete(key string) error {
+	config, err := m.GetByKey(key)
+
+	if err != nil {
+		return err
+	}
+
+	return m.collection.Remove(config)
+}

--- a/identityservice/service.go
+++ b/identityservice/service.go
@@ -3,10 +3,17 @@ package identityservice
 import (
 	"github.com/gorilla/mux"
 
+	"github.com/itsyouonline/identityserver/db"
 	"github.com/itsyouonline/identityserver/identityservice/company"
+	"github.com/itsyouonline/identityserver/identityservice/globalconfig"
 	"github.com/itsyouonline/identityserver/identityservice/organization"
 	"github.com/itsyouonline/identityserver/identityservice/user"
 	"github.com/itsyouonline/identityserver/identityservice/userorganization"
+
+	"crypto/rand"
+	"encoding/base64"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 //Service is the identityserver http service
@@ -33,4 +40,60 @@ func (service *Service) AddRoutes(router *mux.Router) {
 	userorganization.UserorganizationsInterfaceRoutes(router, userorganization.UsersusernameorganizationsAPI{})
 	organization.InitModels()
 
+}
+
+func generateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+
+	// Note that err == nil only if we read len(b) bytes.
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Generate a random string (s length) used for secret cookie
+func generateCookieSecret(s int) (string, error) {
+	b, err := generateRandomBytes(s)
+	return base64.URLEncoding.EncodeToString(b), err
+}
+
+// Get secret cookie from mongodb if exists otherwise, generate a new one and save it
+func GetCookieSecret() string {
+	session := db.GetSession()
+	defer session.Close()
+
+	config := globalconfig.NewManager()
+	globalconfig.InitModels()
+
+	cookie, err := config.GetByKey("cookieSecret")
+	if err != nil {
+		log.Debug("No cookie secret found, generating a new one")
+
+		secret, err := generateCookieSecret(32)
+
+		if err != nil {
+			log.Panic("Cannot generate secret cookie")
+		}
+
+		cookie.Key = "cookieSecret"
+		cookie.Value = secret
+
+		err = config.Insert(cookie)
+
+		// Key was inserted by another instance in the meantime
+		if db.IsDup(err) {
+			cookie, err = config.GetByKey("cookieSecret")
+
+			if err != nil {
+				log.Panic("Cannot retreive cookie secret")
+			}
+		}
+	}
+
+	log.Debug("Cookie secret: ", cookie.Value)
+
+	return cookie.Value
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -16,7 +16,9 @@ import (
 func GetRouter() http.Handler {
 	r := mux.NewRouter().StrictSlash(true)
 
-	siteservice := siteservice.NewService()
+	cookieSecret := identityservice.GetCookieSecret()
+
+	siteservice := siteservice.NewService(cookieSecret)
 	siteservice.AddRoutes(r)
 
 	apiRouter := r.PathPrefix("/api").Subrouter()

--- a/siteservice/service.go
+++ b/siteservice/service.go
@@ -23,9 +23,9 @@ type Service struct {
 }
 
 //NewService creates and initializes a Service
-func NewService() (service *Service) {
+func NewService(cookieSecret string) (service *Service) {
 	service = &Service{}
-	service.initializeSessions()
+	service.initializeSessions(cookieSecret)
 	return
 }
 

--- a/siteservice/session.go
+++ b/siteservice/session.go
@@ -17,11 +17,10 @@ const (
 	SessionInteractive SessionType = iota
 )
 
-func (service *Service) initializeSessions() {
+func (service *Service) initializeSessions(cookieSecret string) {
 	service.Sessions = make(map[SessionType]*sessions.CookieStore)
 
-	//TODO: https://github.com/itsyouonline/identityserver/issues/6
-	cookieStoreSecret := "TODO: ISSUE #6"
+	cookieStoreSecret := cookieSecret
 
 	registrationSessionStore := sessions.NewCookieStore([]byte(cookieStoreSecret))
 	registrationSessionStore.Options.HttpOnly = true

--- a/siteservice/session_test.go
+++ b/siteservice/session_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAvailableSessions(t *testing.T) {
 
-	siteService := NewService()
+	siteService := NewService("MyCookieSecret")
 	request := &http.Request{}
 
 	session, err := siteService.GetSession(request, SessionForRegistration, "akey")


### PR DESCRIPTION
In order to close issue #6 
On the first run, if there is no secretCookie found in mongodb, one is generated then saved. Other instance will find it and use the same after that.

This pull request implement a "globalconfig" way usable to store any general settings/config/key-value stuff