### PR TITLE
Use absolute URI for Oauth2

### DIFF
--- a/specifications/api/securitySchemes/oauth_2_0.raml
+++ b/specifications/api/securitySchemes/oauth_2_0.raml
@@ -17,8 +17,8 @@ describedBy:
     404:
       description: Unauthorized
 settings:
-  authorizationUri: /v1/oauth/authorize
-  accessTokenUri: /v1/oauth/access_token
+  authorizationUri: https://itsyou.online/v1/oauth/authorize
+  accessTokenUri: https://itsyou.online/v1/oauth/access_token
   authorizationGrants: [ authorization_code, client_credentials ]
   scopes:
     - "user:admin"


### PR DESCRIPTION
Base URI is https://itsyou.online/api and we don't want `api` suffix in Oauth2