### PR TITLE
Fix string.startsWith polyfill for ancient browsers

### DIFF
--- a/siteservice/website/components/patches.js
+++ b/siteservice/website/components/patches.js
@@ -1,7 +1,8 @@
 function initializePolyfills() {
   if (!String.prototype.startsWith) {
-      String.prototype.startsWith = function (haystack, needle) {
-          return haystack.lastIndexOf(needle, 0) === 0;
+      String.prototype.startsWith = function (searchString, position) {
+          position = position || 0;
+          return this.substr(position, searchString.length) === searchString;
       };
   }
   if (!String.prototype.includes) {


### PR DESCRIPTION
Should fix the issues where some scopes aren't being shown on the on the authorize page