### PR TITLE
feat(oauth): Add the possibility to redirect to the register page

### DIFF
--- a/docs/oauth2/oauth2.md
+++ b/docs/oauth2/oauth2.md
@@ -52,6 +52,8 @@ https://itsyou.online/v1/oauth/authorize?response_type=code&client_id=CLIENT_ID&
 * state=STATE
 
     A random string. It is used to protect against csrf attacks.
+    
+Optionally, a `register` query parameter with a non-empty value can be supplied to redirect the user to the registration page instead of the login page.
 
 ### Step 2: User Authorizes Application
 

--- a/oauthservice/authorize.go
+++ b/oauthservice/authorize.go
@@ -82,11 +82,16 @@ func validateRedirectURI(mgr ClientManager, redirectURI string, clientID string)
 	return
 }
 
-func redirecToLoginPage(w http.ResponseWriter, r *http.Request) {
+func redirectToNextPage(w http.ResponseWriter, r *http.Request) {
 	queryvalues := r.URL.Query()
 	queryvalues.Add("endpoint", r.URL.EscapedPath())
+	redirectToRegistrationPage := r.Form.Get("register") != ""
 	//TODO: redirect according the the received http method
-	http.Redirect(w, r, "/login?"+queryvalues.Encode(), http.StatusFound)
+	if redirectToRegistrationPage {
+		http.Redirect(w, r, "/register?"+queryvalues.Encode(), http.StatusFound)
+	} else {
+		http.Redirect(w, r, "/login?"+queryvalues.Encode(), http.StatusFound)
+	}
 }
 
 func redirectToScopeRequestPage(w http.ResponseWriter, r *http.Request, possibleScopes []string) {
@@ -145,7 +150,7 @@ func (service *Service) AuthorizeHandler(w http.ResponseWriter, request *http.Re
 			log.Debug("protected session")
 			protectedSession = true
 		} else {
-			redirecToLoginPage(w, request)
+			redirectToNextPage(w, request)
 			return
 		}
 	}
@@ -218,7 +223,7 @@ func (service *Service) AuthorizeHandler(w http.ResponseWriter, request *http.Re
 					return
 				}
 			}
-			redirecToLoginPage(w, request)
+			redirectToNextPage(w, request)
 			return
 		}
 		token, e := service.createItsYouOnlineAdminToken(username, request)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "cd node_modules/karma/bin && ./karma start ../../../karma.conf.js --singleRun"
+      "test": "node_modules/karma/bin/karma start karma.conf.js --singleRun"
   },
   "devDependencies": {
     "angular-mocks": "1.5.9",


### PR DESCRIPTION
Make it possible to redirect to the registration page instead of login page during an oauth flow by supplying query parameter 'register'.