### PR TITLE
Add page to filter see documents by organization

### DIFF
--- a/siteservice/website/components/app.js
+++ b/siteservice/website/components/app.js
@@ -128,15 +128,15 @@
                 pageTitle: 'See'
             }
         })
-            .state('seeListOrganization', {
-                url: '/see/:globalid',
-                templateUrl: 'components/see/views/see-list-page.html',
-                controller: 'SeeListController',
-                controllerAs: 'vm',
-                params: {
-                    pageTitle: 'See'
-                }
-            })
+        .state('seeListOrganization', {
+            url: '/see/organization/:globalid',
+            templateUrl: 'components/see/views/see-list-page.html',
+            controller: 'SeeListController',
+            controllerAs: 'vm',
+            params: {
+                pageTitle: 'See'
+            }
+        })
         .state('seeDetail', {
             url: '/see/:uniqueid/:globalid',
             templateUrl: 'components/see/views/see-detail-page.html',

--- a/siteservice/website/components/see/see-list.controller.js
+++ b/siteservice/website/components/see/see-list.controller.js
@@ -6,10 +6,11 @@
 
     function SeeListController($stateParams, UserService) {
         var vm = this;
-        var organization = $stateParams.globalid;
+        vm.organization = $stateParams.globalid;
         vm.documents = [];
         vm.loaded = false;
         vm.userIdentifier = undefined;
+        vm.noDocsTranslation = vm.organization ? 'no_see_documents_for_organization' : 'no_see_documents';
 
         init();
 
@@ -26,7 +27,7 @@
 
         function getDocuments() {
             vm.loaded = false;
-            UserService.getSeeObjects(organization).then(function (documents) {
+            UserService.getSeeObjects(vm.organization).then(function (documents) {
                 vm.documents = documents;
                 vm.loaded = true;
             });

--- a/siteservice/website/components/see/views/see-list-page.html
+++ b/siteservice/website/components/see/views/see-list-page.html
@@ -5,16 +5,20 @@
                 <a class="breadcrumb-link" ui-sref="profile" ng-bind="::vm.userIdentifier"></a>
                 <span>&raquo; </span>
             </span>
-            <span translate='see'></span>
+            <span>
+                <a class="breadcrumb-link" ui-sref="see" translate="see"></a>
+                <span ng-if="vm.organization">&raquo; </span>
+            </span>
+            <span ng-bind="vm.organization"></span>
         </p>
-        <h1 translate='iyo_see'></h1>
+        <h1 translate="iyo_see"></h1>
     </div>
     <md-card>
         <md-card-content>
             <div class="loading-container" layout-align="center center" ng-if="!vm.loaded">
                 <md-progress-circular md-mode="indeterminate" md-diameter="50"></md-progress-circular>
             </div>
-            <p ng-if="!vm.documents.length && vm.loaded" translate='no_see_documents'></p>
+            <p ng-if="!vm.documents.length && vm.loaded" translate="{{ vm.noDocsTranslation }}"></p>
             <see-detail see="see" detailed="false" ng-repeat="see in vm.documents"></see-detail>
         </md-card-content>
     </md-card>


### PR DESCRIPTION
Currently it only was possible to filter by organization by visiting said organization, which implies that you need to be member of it.
This adds a page `#/see/organization/{globalid}` which filters the list of see documents by organization globalid.