### PR TITLE
Allow Bearer with capital B for JWT

### DIFF
--- a/credentials/oauth2/jwt.go
+++ b/credentials/oauth2/jwt.go
@@ -15,10 +15,10 @@ import (
 // Validation against the supplied publickey is performed
 func GetValidJWT(r *http.Request, publicKey *ecdsa.PublicKey) (token *jwt.Token, err error) {
 	authorizationHeader := r.Header.Get("Authorization")
-	if !strings.HasPrefix(authorizationHeader, "bearer ") {
+	if !strings.HasPrefix(authorizationHeader, "bearer ") && !strings.HasPrefix(authorizationHeader, "Bearer ") {
 		return
 	}
-	jwtstring := strings.TrimSpace(strings.TrimPrefix(authorizationHeader, "bearer"))
+	jwtstring := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(authorizationHeader, "Bearer"), "bearer"))
 	token, err = jwt.Parse(jwtstring, func(token *jwt.Token) (interface{}, error) {
 		m, ok := token.Method.(*jwt.SigningMethodECDSA)
 		if !ok {

--- a/identityservice/security/oauth2.go
+++ b/identityservice/security/oauth2.go
@@ -24,7 +24,7 @@ func (om *OAuth2Middleware) GetAccessToken(r *http.Request) string {
 		accessTokenQueryParameter := r.URL.Query().Get("access_token")
 		return accessTokenQueryParameter
 	}
-	if strings.HasPrefix(authorizationHeader, "bearer ") {
+	if strings.HasPrefix(authorizationHeader, "bearer ") || strings.HasPrefix(authorizationHeader, "Bearer ") {
 		return ""
 	}
 	accessToken := strings.TrimSpace(strings.TrimPrefix(authorizationHeader, "token"))


### PR DESCRIPTION
The standard dictates to use "Authorization: Bearer <token>"
This PR allows IYO to support both bearer and Bearer to be backwards
compatible and standard compliant

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>