### PR TITLE
Allow omitting state parameter from access token request

### DIFF
--- a/docs/oauth2/oauth2.md
+++ b/docs/oauth2/oauth2.md
@@ -79,7 +79,7 @@ POST https://itsyou.online/v1/oauth/access_token?client_id=CLIENT_ID&client_secr
 
 Note: Alternativly one can pass the `client_id` and `client_secret` via basic authentication header and ommit them from the post data.
 
-The redirect_uri must match the redirect_uri passed in the access_code request and the callback URI registered in the api key. The redirect URL's host and port must exactly match the callback URL and the redirect URL's path must reference a subdirectory of the callback URL. The state must match the state received with the authorization code
+The redirect_uri must match the redirect_uri passed in the access_code request and the callback URI registered in the api key. The redirect URL's host and port must exactly match the callback URL and the redirect URL's path must reference a subdirectory of the callback URL. The state parameter is optional but if sent, it must match the state received with the authorization code
 
 * response_type=code
 

--- a/oauthservice/access_token.go
+++ b/oauthservice/access_token.go
@@ -244,7 +244,7 @@ func convertCodeToAccessTokenHandler(code string, clientID string, secret string
 		return
 	}
 
-	if ar.ClientID != clientID || ar.State != state || ar.RedirectURL != redirectURI {
+	if ar.ClientID != clientID || (state != "" && ar.State != state) || ar.RedirectURL != redirectURI {
 		log.Debugf("Client id:%s - Expected client id:%s", clientID, ar.ClientID)
 		log.Debugf("State:%s - Expected state:%s", state, ar.State)
 		log.Debugf("Redirect url:%s - Expected redirect url:%s", redirectURI, ar.RedirectURL)


### PR DESCRIPTION
As per the standard specification of oauth2 the state parameter shouldn't be resend again to get the access token
https://tools.ietf.org/html/rfc6749#section-1.2

Examples for libraries encountered so far which doesn't support itsyou.online for this reason:
[loginsrv](https://github.com/tarent/loginsrv)
[goth](https://github.com/markbates/goth)

Fixes: #664 